### PR TITLE
target framework net7.0 + version bumps

### DIFF
--- a/src/DotNetSearch/DotNetSearch.csproj
+++ b/src/DotNetSearch/DotNetSearch.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <AssemblyName>dotnet-search</AssemblyName>
@@ -16,7 +16,7 @@ Example: dotnet search json.net</Description>
     <PackageProjectUrl>https://github.com/billpratt/dotnet-search</PackageProjectUrl>
     <RepositoryUrl>https://github.com/billpratt/dotnet-search</RepositoryUrl>
     <PackageTags>dotnet, search</PackageTags>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Authors>Bill Pratt</Authors>
     <Company />
     <Product />
@@ -24,8 +24,8 @@ Example: dotnet search json.net</Description>
 
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.4" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This tool is incredibly useful, thank you for creating it 👍🏽.

This PR
- upgrades the targetPlatfrom to net7.0
- upgrades the dependencies (Newton had already a vulnerability)

I ran the tool successfully afterwards in my IDE:

````
C:/work/Projects/dotnet-search/src/DotNetSearch/bin/Debug/net7.0/dotnet-search.exe
>  --version
dotnet-search
1.0.1
>  TestContainers -t 1
Name             Description                 Authors                     Version   Downloads   Verified
_______________________________________________________________________________________________________
Testcontainers   Testcontainers for          Andre Hofmeister and        3.5.0     3.88M          *
                 .NET is a library to        contributors
                 support tests with
                 throwaway instances
                 of Docker containers
                 for all compatible
                 .NET Standard
                 versions.

1 - 1 of 65 results
>
````